### PR TITLE
142728409 kh 404 route

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1,28 +1,36 @@
 import React, { Component } from 'react';
-import { BrowserRouter as Router, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 
 import Main from '../main/Main';
 import Johari from '../johari/Johari';
 import Sidebar from '../sidebar/Sidebar';
+import NoMatch from '../no-match/NoMatch';
 
 class App extends Component {
   render() {
     return (
       <div className='App'>
+
         <Router>
           <div className='Router'>
             <Sidebar />
-            <Route
-              key='1'
-              path='/johari/:id'
-              render={ ({match}) => <Johari evaluateeID={match.params.id} /> }
-            />
-            <Route
-              key='2'
-              exact={true}
-              path='/'
-              render={ () => <Main /> }
-            />
+            <Switch>
+              <Route
+                key='1'
+                path='/johari/:id'
+                render={ ({match}) => <Johari evaluateeID={match.params.id} /> }
+              />
+              <Route
+                key='2'
+                exact={true}
+                path='/'
+                render={ () => <Main /> }
+              />
+              <Route
+                key='3'
+                render={ () => <NoMatch /> }
+              />
+            </ Switch >
           </div>
         </Router>
       </div>

--- a/src/no-match/NoMatch.js
+++ b/src/no-match/NoMatch.js
@@ -1,0 +1,15 @@
+import React, { Component } from 'react';
+import './NoMatch.css';
+
+class NoMatch extends Component {
+
+  render() {
+    return (
+      <div className='NoMatch'>
+        <h3>Page Not Found (404)</h3>
+      </div>
+    )
+  }
+}
+
+export default NoMatch;

--- a/src/no-match/NoMatch.test.js
+++ b/src/no-match/NoMatch.test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import NoMatch from './NoMatch';
+
+describe('NoMatch', () => {
+
+  let wrapper;
+
+  beforeEach(() => wrapper = shallow(<NoMatch />))
+
+  it('renders no match', () => {
+
+    expect(wrapper.find('.NoMatch').length).toEqual(1)
+  })
+})


### PR DESCRIPTION
Add a 404 route that captures all unhandled routes and displays 'Page Not Found (404)'

A couple notes:
-Right now the sidebar still renders and the 404 will render the in main div to the right of the sidebar. Thoughts on whether this is ok?
-Visiting `/johari/x` for any integer x will still render that page. The user still can't make the post unless there is an assignment since the API is built that way. We would have to pass in a list of valid assignments (or save it somehow) to make it impossible to visit that page.

@Dpalazzari @lucyconklin @wlffann @akintner Needs one reviewer.

@case-eee FYI
