### PR TITLE
142811721 kh cache adjectives and users

### DIFF
--- a/src/adjective-list/AdjectiveList.js
+++ b/src/adjective-list/AdjectiveList.js
@@ -11,16 +11,29 @@ class AdjectiveList extends Component {
     this.eachAdjective = this.eachAdjective.bind(this);
   }
 
-  toggleAdjective(adjective) {
-    this.props.toggleAdjective(adjective)
+  componentDidMount() {
+    if (localStorage.adjectives) { this.setAdjectivesLocally() }
+    else { this.retrieveAdjectives() }
   }
 
-  componentDidMount() {
-    var that = this;
+  setAdjectivesLocally() {
+    var adjectiveList = localStorage.getItem('adjectives').split(',')
+    this.setState({ adjectives: adjectiveList })
+  }
 
+  retrieveAdjectives() {
+    var that = this;
     fetch('https://johariwindowapi.herokuapp.com/api/v1/adjectives')
-      .then(result => result.json())
-      .then(data => that.setState({ adjectives: data }))
+        .then(result => result.json())
+        .then(data => {
+          that.setState({ adjectives: data })
+          localStorage.setItem('adjectives', data)
+          return true
+        })    
+  }
+
+  toggleAdjective(adjective) {
+    this.props.toggleAdjective(adjective)
   }
 
   eachAdjective(name, i) {

--- a/src/adjective-list/AdjectiveList.test.js
+++ b/src/adjective-list/AdjectiveList.test.js
@@ -3,15 +3,18 @@ import { shallow, mount } from 'enzyme';
 import AdjectiveList from './AdjectiveList';
 import Adjective from '../adjective/Adjective';
 
+global.localStorage = {}
+
 describe('AdjectiveList', () => {
-  it('renders without crashing', () => {
-    shallow(<AdjectiveList />);
-  });
+
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = mount(<AdjectiveList />)
+  })
 
   it('renders adjective components based on state', () => {
-    const assignedAdjectives = ['religious', 'happy', 'brave']
-    const wrapper = mount(<AdjectiveList/>);
-    wrapper.setState({ adjectives: assignedAdjectives })
+    const assignedAdjectives = ['religious', 'happy', 'brave'];    wrapper.setState({ adjectives: assignedAdjectives })
 
     expect(wrapper.find('.Adjective').length).toEqual(assignedAdjectives.length)
   });

--- a/src/johari/Johari.js
+++ b/src/johari/Johari.js
@@ -11,12 +11,14 @@ class Johari extends Component {
     this.state = { evaluateeName: '', adjectives: [] };
 
     this.toggleAdjective = this.toggleAdjective.bind(this);
-    this.getName = this.getName.bind(this);
+    this.retrieveNameAndSetLocally = this.retrieveNameAndSetLocally.bind(this);
     this.readyToSubmit = this.readyToSubmit.bind(this);
   }
 
   componentDidMount() {
-    this.getName()
+    var user = 'user' + this.props.evaluateeID
+    if (localStorage[user]) { this.setNameLocally(user) } 
+    else { this.retrieveNameAndSetLocally(user) }
   }
 
   toggleAdjective(adjective) {
@@ -33,10 +35,18 @@ class Johari extends Component {
     return (this.state.adjectives.length === 10)
   }
 
-  getName() {
+  retrieveNameAndSetLocally(user) {
     fetch(`https://johariwindowapi.herokuapp.com/api/v1/users/${this.props.evaluateeID}`)
     .then(result => result.json())
-    .then(data => this.setState({ evaluateeName: data.name }))
+    .then(data => {
+      this.setState({ evaluateeName: data.name })
+      localStorage.setItem(user, data.name)
+      return true
+    })
+  }
+
+  setNameLocally(user) {
+    this.setState({ evaluateeName: localStorage[user] })
   }
 
   render() {

--- a/src/johari/Johari.test.js
+++ b/src/johari/Johari.test.js
@@ -3,12 +3,15 @@ import { shallow, mount } from 'enzyme';
 import Johari from './Johari';
 import { BrowserRouter as Router } from 'react-router-dom';
 
+global.localStorage = {}
 
 describe('Johari', () => {
 
   let wrapper;
 
-  beforeEach(() => wrapper = mount(<Router><Johari /></Router>))
+  beforeEach(() => {
+    wrapper = mount(<Router><Johari /></Router>)
+  })
 
    it('renders directions', () => {
 


### PR DESCRIPTION
Implement local storage to save adjectives list and user names based on id.

Visually page is loading quite a bit faster. Maybe we can some more rigorous work with load times later on. Here is a picture of what local storage looks like. Users are saved on the outer level of local storage as `user12`.

<img width="562" alt="screen shot 2017-04-01 at 4 54 08 pm" src="https://cloud.githubusercontent.com/assets/16868275/24583062/08ce271a-16fc-11e7-888e-d1032c21a2ab.png">

@lucyconklin @Dpalazzari @akintner @wlffann One reviewer should be good.

@case-eee FYI